### PR TITLE
Use stacked axes for weekly chart

### DIFF
--- a/frontend/src/components/excess_deaths_chart.vue
+++ b/frontend/src/components/excess_deaths_chart.vue
@@ -22,6 +22,7 @@ export default {
             gridLines: {
               display: true,
             },
+            stacked: true,
           },
         ],
         xAxes: [
@@ -29,6 +30,7 @@ export default {
             gridLines: {
               display: false,
             },
+            stacked: true,
           },
         ],
       },

--- a/frontend/src/components/home_page.vue
+++ b/frontend/src/components/home_page.vue
@@ -258,7 +258,6 @@ export default {
         .then((res) => {
           this.labels = res.data.label;
           this.deaths = res.data.deaths;
-          this.excess_deaths = res.data.excess_deaths;
           this.expected_deaths = res.data.expected_deaths;
           this.above_expectation_deaths = res.data.above_expectation_deaths;
           this.below_expectation_deaths = res.data.below_expectation_deaths;
@@ -268,7 +267,7 @@ export default {
               {
                 pointBackgroundColor: "#000000",
                 pointBorderColor: "#000000",
-                borderWidth: 1,
+                borderWidth: 2,
                 pointRadius: 1,
                 type: "line",
                 backgroundColor: "#000000",
@@ -279,9 +278,9 @@ export default {
                 lineTension: 0,
               },
               {
-                backgroundColor: "#F44336",
-                label: "Excess deaths",
-                data: this.above_expectation_deaths,
+                backgroundColor: "#1A237E",
+                label: "Actual deaths up to expected",
+                data: this.deaths,
               },
               {
                 backgroundColor: "#4CAF50",
@@ -289,9 +288,9 @@ export default {
                 data: this.below_expectation_deaths,
               },
               {
-                backgroundColor: "#1A237E",
-                label: "Actual deaths",
-                data: this.deaths,
+                backgroundColor: "#F44336",
+                label: "Excess deaths",
+                data: this.above_expectation_deaths,
               },
             ],
           };

--- a/frontend/src/components/home_page.vue
+++ b/frontend/src/components/home_page.vue
@@ -86,6 +86,8 @@
           starting from <b>p - 104 weeks</b> to <b>p - 52 weeks</b>. The growth
           of that linear regression is applied to the above calculated mean of
           previous observations to arrive at the expectation value for <b>p</b>.
+          The moving average over 4 weeks is computed to smooth out the
+          resulting expected deaths time series.
           <br />
           <br />
           The model to compute the epxected deaths thus has an effective

--- a/frontend/src/components/home_page.vue
+++ b/frontend/src/components/home_page.vue
@@ -125,7 +125,7 @@
           v-if="excess_deaths_request_successful"
           class="font-weight-bold mb-3 text-center"
         >
-          All-cause mortality chart for country {{ country_selection }}
+          Weekly all-cause mortality for country {{ country_selection }}
         </h2>
         <excess_deaths_chart
           v-if="excess_deaths_request_successful"
@@ -192,7 +192,7 @@ export default {
     // UI options
     calendar_week_options: Array.from({ length: 53 }, (x, i) => i + 1),
     geo_options: [],
-    available_age_groups: {},
+    available_age_groups: [],
     available_years: [],
 
     // Chart data

--- a/mortality_monitor/server.py
+++ b/mortality_monitor/server.py
@@ -82,27 +82,23 @@ def excess_deaths():
             .pipe(_filter_on_year, year=user_input[YEAR])
         )
         deaths = deaths.pipe(_filter_on_year, year=user_input[YEAR])
-
-        excess_deaths = deaths - expected_deaths
         periods = deaths.index
 
-        above_expectation_deaths = [
-            -np.abs(value) if (value > 0) else 0
-            for value in excess_deaths.values.round().tolist()
-        ]
-        below_expectation_deaths = [
-            -np.abs(value) if (value <= 0) else 0
-            for value in excess_deaths.values.round().tolist()
-        ]
+        above_expectation_deaths = np.where(
+            deaths > expected_deaths, deaths - expected_deaths, 0
+        )
+        below_expectation_deaths = np.where(
+            deaths <= expected_deaths, expected_deaths - deaths, 0
+        )
+        deaths = np.where(deaths < expected_deaths, deaths, expected_deaths)
 
         return jsonify(
             {
-                "deaths": deaths.values.round().tolist(),
+                "deaths": deaths.round().tolist(),
                 "label": [f"{period.year}/{period.week}" for period in periods],
-                "excess_deaths": excess_deaths.values.round().tolist(),
-                "expected_deaths": expected_deaths.values.round().tolist(),
-                "above_expectation_deaths": above_expectation_deaths,
-                "below_expectation_deaths": below_expectation_deaths,
+                "expected_deaths": expected_deaths.round().tolist(),
+                "above_expectation_deaths": above_expectation_deaths.round().tolist(),
+                "below_expectation_deaths": below_expectation_deaths.round().tolist(),
             }
         )
 

--- a/mortality_monitor/server.py
+++ b/mortality_monitor/server.py
@@ -75,8 +75,11 @@ def excess_deaths():
             geo=user_input[GEO_COLUMN],
             ages=user_input[AGE_COLUMN],
         )
-        expected_deaths = get_expected_deaths(deaths=deaths).pipe(
-            _filter_on_year, year=user_input[YEAR]
+        expected_deaths = (
+            get_expected_deaths(deaths=deaths)
+            .rolling(window=4)
+            .mean()
+            .pipe(_filter_on_year, year=user_input[YEAR])
         )
         deaths = deaths.pipe(_filter_on_year, year=user_input[YEAR])
 


### PR DESCRIPTION
This PR

- updates the weekly excess deaths chart with a clearer representation of the data by not projecting excess- and below expectation deaths onto the negative y-axis
- applies a rolling average to the expected deaths curve to smooth it out a little
- cleans up the home page script a little bit