### PR TITLE
Get start or end time year depending on week

### DIFF
--- a/mortality_monitor/server.py
+++ b/mortality_monitor/server.py
@@ -95,9 +95,7 @@ def excess_deaths():
         return jsonify(
             {
                 "deaths": deaths.round().tolist(),
-                "label": [
-                    f"{period.start_time.year}/{period.week}" for period in periods
-                ],
+                "label": [_get_period_representation(period) for period in periods],
                 "expected_deaths": expected_deaths.round().tolist(),
                 "above_expectation_deaths": above_expectation_deaths.round().tolist(),
                 "below_expectation_deaths": below_expectation_deaths.round().tolist(),
@@ -144,6 +142,18 @@ def _filter_on_year(data: pd.Series, year: int) -> pd.Series:
         .query("year >= @year")
         .drop(columns=[YEAR])
         .set_index(PERIOD_COLUMN)[column_name]
+    )
+
+
+def _get_period_representation(p: pd.Period) -> str:
+    if p.start_time.year == p.end_time.year:
+        return f"{p.start_time.year}/{p.week}"
+    elif p.week == 1:
+        return f"{p.end_time.year}/{p.week}"
+    elif p.week >= 52:
+        return f"{p.start_time.year}/{p.week}"
+    raise ValueError(
+        f"Period {p} has unequal start/end time years and is not in week 1, 52 or 53."
     )
 
 


### PR DESCRIPTION
- Fix issue where year was wrongly attributed to past year in edge cases
- Specifically for period `2020-01` which goes from `2019-12-29` to `2020-01-04` the label sent by the server was `2019-01` by only considering the `start_time` of the period. 
- The new logic correctly uses the `end_time` to get the `year` when the period has calendar week `01`. For calendar weeks 52 and 53 we take the `start_time` (if and only if `period.start_time.year != period.end_time.year`)