### PR TITLE
Update setuptools prior to installing requirements in CI

### DIFF
--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -19,7 +19,7 @@ jobs:
         python-version: "3.8.12"
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
+        python -m pip install --upgrade setuptools pip
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Check formatting with isort and black
       run: |

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,6 @@ packaging==23.1
 pandas==1.3.5
 pandas-stubs==1.2.0.39
 pathspec==0.11.1
-pkg_resources==0.0.0
 platformdirs==3.5.0
 pluggy==1.0.0
 pycodestyle==2.8.0


### PR DESCRIPTION
PR also removes a buggy dependency in the requirements file which is introduced when pip freezing on an ubuntu machine: https://stackoverflow.com/questions/39577984/what-is-pkg-resources-0-0-0-in-output-of-pip-freeze-command